### PR TITLE
Send API token via header

### DIFF
--- a/wa-system/api/waAPIController.class.php
+++ b/wa-system/api/waAPIController.class.php
@@ -142,6 +142,10 @@ class waAPIController
     protected function checkToken()
     {
         $token = waRequest::request('access_token');
+        if (!$token) {
+            $token = waRequest::server('Authorization');
+            $token = preg_replace('~^(Bearer\s)~ui', '', $token);
+        }
         if ($token) {
             $tokens_model = new waApiTokensModel();
             $data = $tokens_model->getById($token);


### PR DESCRIPTION
Sending an API token via the GET-parameter is not always secure.

SR: https://developers.webasyst.ru/forum/35999/ispolzovanie-api-s-bezopasnoy-peredachey-tokena/#comment116939